### PR TITLE
[bug fix] handle cifar10

### DIFF
--- a/src/datasets/cifar10.py
+++ b/src/datasets/cifar10.py
@@ -40,7 +40,7 @@ class CIFAR10_Dataset(TorchvisionDataset):
         train_set = MyCIFAR10(root=self.root, train=True, download=True,
                               transform=transform, target_transform=target_transform)
         # Subset train set to normal class
-        train_idx_normal = get_target_label_idx(train_set.train_labels, self.normal_classes)
+        train_idx_normal = get_target_label_idx(train_set.targets, self.normal_classes)
         self.train_set = Subset(train_set, train_idx_normal)
 
         self.test_set = MyCIFAR10(root=self.root, train=False, download=True,
@@ -61,9 +61,9 @@ class MyCIFAR10(CIFAR10):
             triple: (image, target, index) where target is index of the target class.
         """
         if self.train:
-            img, target = self.train_data[index], self.train_labels[index]
+            img, target = self.data[index], self.targets[index]
         else:
-            img, target = self.test_data[index], self.test_labels[index]
+            img, target = self.data[index], self.targets[index]
 
         # doing this so that it is consistent with all other datasets
         # to return a PIL Image

--- a/src/main.py
+++ b/src/main.py
@@ -176,8 +176,8 @@ def main(dataset_name, net_name, xp_path, data_path, load_config, load_model, ob
             X_outliers = dataset.test_set.test_data[idx_sorted[-32:], ...].unsqueeze(1)
 
         if dataset_name == 'cifar10':
-            X_normals = torch.tensor(np.transpose(dataset.test_set.test_data[idx_sorted[:32], ...], (0, 3, 1, 2)))
-            X_outliers = torch.tensor(np.transpose(dataset.test_set.test_data[idx_sorted[-32:], ...], (0, 3, 1, 2)))
+            X_normals = torch.tensor(np.transpose(dataset.test_set.data[idx_sorted[:32], ...], (0, 3, 1, 2)))
+            X_outliers = torch.tensor(np.transpose(dataset.test_set.data[idx_sorted[-32:], ...], (0, 3, 1, 2)))
 
         plot_images_grid(X_normals, export_img=xp_path + '/normals', title='Most normal examples', padding=2)
         plot_images_grid(X_outliers, export_img=xp_path + '/outliers', title='Most anomalous examples', padding=2)


### PR DESCRIPTION
With the provided coded, the example on cifar10 was failing. It seems that the cifar10 dataset does not have "train_labels" and "train/test_data" but respectively "targets" and "data".

This fix proposes a name change at key places to be able to run the example